### PR TITLE
Update doc.go to fix dependency for 1.7-release

### DIFF
--- a/pkg/apis/apiextensions/doc.go
+++ b/pkg/apis/apiextensions/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 // Package apiextensions is the internal version of the API.
 // +groupName=apiextensions.k8s.io
-package apiextensions // import "k8s.io/apiextension-server/pkg/apis/apiextensions"
+package apiextensions // import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"


### PR DESCRIPTION
Fixing dependency for 1.7-release
```
release-1.7: Could not introduce k8s.io/apiextensions-apiserver@release-1.7, as its subpackage k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1 does not contain usable Go code (*pkgtree.NonCanonicalImportRoot).. (Package is required by (root).)
```